### PR TITLE
Fix deprecation warning for is_nan() in PHP 8.1

### DIFF
--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -244,8 +244,8 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 			$e2 = (($c1 & 3) << 4) + ($c2 >> 4);
 			$e3 = (($c2 & 15) << 2) + ($c3 >> 6);
 			$e4 = $c3 & 63;
-			if(is_nan($c2)) $e3 = $e4 = 64;
-			else if(is_nan($c3)) $e4 = 64;
+			if(!is_null($c2) && is_nan($c2)) $e3 = $e4 = 64;
+			else if(!is_null($c3) && is_nan($c3)) $e4 = 64;
 			$out .= $key[$e1] . $key[$e2] . $key[$e3] . $key[$e4];
 		}
 		return $out;


### PR DESCRIPTION
This pull request fixes Issue #13, but differently than described by the opener.
Please check again if this makes sense.