### PR TITLE
Fix: @ sign or email in URL resulted in broken markup

### DIFF
--- a/EmailObfuscation.info.json
+++ b/EmailObfuscation.info.json
@@ -1,6 +1,6 @@
 {
   "title": "Email Obfuscation (EMO)",
-  "version": 130,
+  "version": 131,
   "summary": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "href": "https://github.com/BlowbackAgency/EmailObfuscation",

--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -4,7 +4,7 @@
  *
  * Email Obfuscation module for email addresses with 64 base crypting.
  *
- * @version 1.3.0
+ * @version 1.3.1
  * @copyright Blowback https://github.com/BlowbackDesign
  * @license MIT https://opensource.org/license/mit/
  *
@@ -318,6 +318,7 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 			'<inpu' => "((?:<input).*(?:>))",
 			'value' => "((?:value=['\"]).*(?:['\"]))",
 			'label' => "((?:label=['\"]).*(?:['\"]))",
+			'href=' => "((?:href=['\"](?!mailto:)(?:[a-z]+:|\/|#)).*(?:['\"]))",
 			'data-' => "((?:data-[A-Z0-9.-]+=['\"]).*(?:['\"]))",
 		);
 

--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -318,7 +318,7 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 			'<inpu' => "((?:<input).*(?:>))",
 			'value' => "((?:value=['\"]).*(?:['\"]))",
 			'label' => "((?:label=['\"]).*(?:['\"]))",
-			'href=' => "((?:href=['\"](?!mailto:)(?:[a-z]+:|\/|#)).*(?:['\"]))",
+			'href=' => "((?:href=['\"](?!mailto:)(?:[a-z]+:|\/|\\#)).*(?:['\"]))",
 			'data-' => "((?:data-[A-Z0-9.-]+=['\"]).*(?:['\"]))",
 		);
 


### PR DESCRIPTION
URLs such as https://example.com/example@example.com were resulting in broken markup. The links in question were for a service that sends "secure emails" via web interface, and the email is intentionally part of the URL.

Overall it seems to me that the safest thing would be to identify if a href contains non-mailto protocol or no protocol at all, and in that case skip it entirely. Alternative would be to add special handling for URLs such as these, but that sounds to me unnecessarily complex, and seems to introduce minimal benefit.

Does this make sense?

I have tested this at least to the extent that regular mailto: links and simple email addresses still get handled properly. Also, just in case, I tried to make sure that `href="example@example.com"` still works. URL like that would likely be a mistake, but I guess it's best to leave it as-is anyway to avoid the email leaking.

Thanks for considering!

By the way, latest changes in the repo were not tagged; might want to check that as well.